### PR TITLE
The Max of NULL and 0 is NULL. 

### DIFF
--- a/src/Ds/Stack.php
+++ b/src/Ds/Stack.php
@@ -42,7 +42,7 @@ final class Stack implements Collection, \IteratorAggregate, \ArrayAccess
      *                      is less than or equal to the current capacity.
      */
     public function allocate(int $capacity) {
-        $this->capacity = max($this->capacity, $capacity);
+        $this->capacity = max($this->capacity, $capacity) ?? 0;
     }
 
     /**


### PR DESCRIPTION
Update the allocate methods to set the capacity to 0 if the result of max is NULL.
