### PR TITLE
Capacity must always return an int

### DIFF
--- a/src/Ds/Stack.php
+++ b/src/Ds/Stack.php
@@ -51,7 +51,7 @@ final class Stack implements Collection, \IteratorAggregate, \ArrayAccess
      * @return int
      */
     public function capacity(): int {
-        return $this->capacity;
+        return $this->capacity ?? 0;
     }
 
     /**


### PR DESCRIPTION
If $this->capacity is NULL then return 0 to comply with return type.