### PR TITLE
Trait\Collection::copy should return $this

### DIFF
--- a/src/Ds/Traits/Collection.php
+++ b/src/Ds/Traits/Collection.php
@@ -34,7 +34,7 @@ trait Collection
     /**
      * Creates a copy of the collection, equivalent to 'clone'.
      *
-     * @return \Ds\Collection
+     * @return $this
      */
     public function copy()
     {


### PR DESCRIPTION
When ```Trait\Collection::copy()``` returns an instance of ```\Ds\Collection``` it causes ```Trait\Sequence::copy()``` to expect ```$merged``` be in instance of ```\Ds\Collection``` and not ```\Ds\Sequence```.

Although ```$this``` seems also to be incorrect as it actually returns a copy ```$this``` I believe this will resolve a [Scrutinizer bug](https://scrutinizer-ci.com/g/php-ds/polyfill/inspections/83da7e24-8ce7-4c54-853f-735b40b6c5bb/issues/files/src/Ds/Traits/Sequence.php?status=new&selectedLabels%5B0%5D=9&orderField=path&order=asc&fileId=src%2FDs%2FTraits%2FSequence.php&honorSelectedPaths=0).