### PR TITLE
Suggest extension in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "require-dev": {
         "php-ds/tests": "1.0.*"
     },
+    "suggest": {
+        "ext-ds": "to improve performance and memory usage"
+    },
     "scripts": {
         "test": "phpunit -c ./vendor/php-ds/tests/phpunit.xml"
     },


### PR DESCRIPTION
Adds
> php-ds/php-ds suggests installing ext-ds (to improve performance and memory usage)
notice to composer output when extension is not installed.

```console
/tmp/php-ds $ composer install
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Installing php-ds/php-ds (dev-master ff9b3ef)
    Cloning ff9b3ef

php-ds/php-ds suggests installing ext-ds (to improve performance and memory usage)
Writing lock file
Generating autoload files
Changelogs summary:

 - php-ds/php-ds installed in version dev-master
```