### PR TITLE
Add the clone method to ensure that the internal objects will be cloned

### DIFF
--- a/src/Queue.php
+++ b/src/Queue.php
@@ -170,4 +170,12 @@ final class Queue implements \IteratorAggregate, \ArrayAccess, Collection
     {
         throw new Error();
     }
+
+    /**
+     * Ensures that the internal sequence will be cloned too.
+     */
+    public function __clone()
+    {
+        $this->deque = clone $this->deque;
+    }
 }

--- a/src/Set.php
+++ b/src/Set.php
@@ -457,4 +457,12 @@ final class Set implements \IteratorAggregate, \ArrayAccess, Collection
     {
         throw new Error();
     }
+
+    /**
+     * Ensures that the internal table will be cloned too.
+     */
+    public function __clone()
+    {
+        $this->table = clone $this->table;
+    }
 }

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -173,4 +173,12 @@ final class Stack implements \IteratorAggregate, \ArrayAccess, Collection
     {
         throw new Error();
     }
+
+    /**
+     * Ensures that the internal vector will be cloned too.
+     */
+    public function __clone()
+    {
+        $this->vector = clone $this->vector;
+    }
 }


### PR DESCRIPTION
The method __clone was added to \Ds\Queue, \Ds\Set, \Ds\Stack.

The absence of the clone method had caused copying of the link
of the internal object instead of copying the instance
while using the native "clone" php function.