### PR TITLE
Hotfix for 1.2

### DIFF
--- a/src/Hashable.php
+++ b/src/Hashable.php
@@ -26,7 +26,7 @@ interface Hashable
      * Determines if two objects should be considered equal. Both objects will
      * be instances of the same class but may not be the same instance.
      *
-     * @param $obj An instance of the same class to compare to.
+     * @param $obj - An instance of the same class to compare to.
      *
      * @return bool
      */

--- a/src/Hashable.php
+++ b/src/Hashable.php
@@ -26,7 +26,7 @@ interface Hashable
      * Determines if two objects should be considered equal. Both objects will
      * be instances of the same class but may not be the same instance.
      *
-     * @param $obj - An instance of the same class to compare to.
+     * @param $obj An instance of the same class to compare to.
      *
      * @return bool
      */

--- a/src/Map.php
+++ b/src/Map.php
@@ -192,7 +192,7 @@ final class Map implements \IteratorAggregate, \ArrayAccess, Collection
     }
 
     /**
-     * Attempts to look up a key in the table.
+     * Attempts to look up a value in the table.
      *
      * @param $value
      *

--- a/src/Pair.php
+++ b/src/Pair.php
@@ -40,7 +40,7 @@ final class Pair implements \JsonSerializable
      *
      * @return mixed|null
      */
-    public function __get($name)
+    public function __unset($name)
     {
         if ($name === 'key' || $name === 'value') {
             $this->$name = null;

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -55,6 +55,7 @@ final class PriorityQueue implements \IteratorAggregate, Collection
         $copy = new PriorityQueue();
 
         $copy->heap     = $this->heap;
+        $copy->stamp    = $this->stamp;
         $copy->capacity = $this->capacity;
 
         return $copy;

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -14,8 +14,6 @@ final class Queue implements \IteratorAggregate, \ArrayAccess, Collection
 {
     use Traits\GenericCollection;
 
-    const MIN_CAPACITY = 8;
-
     /**
      * @var Deque internal deque to store values.
      */

--- a/src/Traits/Capacity.php
+++ b/src/Traits/Capacity.php
@@ -37,7 +37,7 @@ trait Capacity
     }
 
     /**
-     * @return the structures growth factor.
+     * @return float the structures growth factor.
      */
     protected function getGrowthFactor(): float
     {
@@ -92,7 +92,7 @@ trait Capacity
     }
 
     /**
-     * @return whether capacity should be increased.
+     * @return bool whether capacity should be increased.
      */
     protected function shouldDecreaseCapacity(): bool
     {
@@ -100,7 +100,7 @@ trait Capacity
     }
 
     /**
-     * @return whether capacity should be increased.
+     * @return bool whether capacity should be increased.
      */
     protected function shouldIncreaseCapacity(): bool
     {

--- a/src/Traits/GenericCollection.php
+++ b/src/Traits/GenericCollection.php
@@ -27,7 +27,7 @@ trait GenericCollection
      *
      * @return mixed
      *
-     * @see JsonSerializable
+     * @see \JsonSerializable
      */
     public function jsonSerialize()
     {

--- a/src/Vector.php
+++ b/src/Vector.php
@@ -23,7 +23,7 @@ final class Vector implements \IteratorAggregate, \ArrayAccess, Sequence
     }
 
     /**
-     * @return whether capacity should be increased.
+     * @return bool whether capacity should be increased.
      */
     protected function shouldIncreaseCapacity(): bool
     {


### PR DESCRIPTION
1. Fix the magic method name for unset()
2. Remove const MIN_CAPACITY assignment in Queue
3. Assign the current stamp to the instance copy
4. Fix documentation content.