### PR TITLE
Use self instead of Collection as a return type for Collection::copy()

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -25,9 +25,9 @@ interface Collection extends \Traversable, \Countable, \JsonSerializable
     /**
      * Returns a shallow copy of the collection.
      *
-     * @return Collection a copy of the collection.
+     * @return static a copy of the collection.
      */
-    function copy(): Collection;
+    function copy();
 
     /**
      * Returns whether the collection is empty.

--- a/src/Pair.php
+++ b/src/Pair.php
@@ -52,10 +52,8 @@ final class Pair implements \JsonSerializable
 
     /**
      * Returns a copy of the Pair
-     *
-     * @return Pair
      */
-    public function copy(): Pair
+    public function copy(): self
     {
         return new self($this->key, $this->value);
     }

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -50,7 +50,7 @@ final class PriorityQueue implements \IteratorAggregate, Collection
     /**
      * @inheritDoc
      */
-    public function copy(): \Ds\Collection
+    public function copy(): self
     {
         $copy = new PriorityQueue();
 

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -63,7 +63,7 @@ final class Queue implements \IteratorAggregate, \ArrayAccess, Collection
     /**
      * @inheritDoc
      */
-    public function copy(): \Ds\Collection
+    public function copy(): self
     {
         return new self($this->deque);
     }

--- a/src/Set.php
+++ b/src/Set.php
@@ -101,7 +101,7 @@ final class Set implements \IteratorAggregate, \ArrayAccess, Collection
     /**
      * @inheritDoc
      */
-    public function copy(): \Ds\Collection
+    public function copy(): self
     {
         return new self($this);
     }

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -40,7 +40,7 @@ final class Stack implements \IteratorAggregate, \ArrayAccess, Collection
     /**
      * @inheritdoc
      */
-    public function copy(): Collection
+    public function copy(): self
     {
         return new self($this->vector);
     }

--- a/src/Traits/GenericCollection.php
+++ b/src/Traits/GenericCollection.php
@@ -39,7 +39,7 @@ trait GenericCollection
      */
     public function copy(): self
     {
-        return new self($this);
+        return new static($this);
     }
 
     /**


### PR DESCRIPTION
Keeping return TH on `copy()` is possible since 7.4 so for now it makes sense to me to keep it like this.