### PR TITLE
Fix handling of initial capacity for Deque

### DIFF
--- a/src/Traits/GenericSequence.php
+++ b/src/Traits/GenericSequence.php
@@ -27,6 +27,11 @@ trait GenericSequence
         if ($values) {
             $this->pushAll($values);
         }
+
+        $this->capacity = max(
+            $values === null ? 0 : count($values),
+            $this::MIN_CAPACITY
+        );
     }
 
     /**


### PR DESCRIPTION
This one is tricky. Deque uses SquareCapacity though when initiated with 64 values it has capacity `64` when used through ext-ds.

I'm not certain about this fix but `DequeTest::testAutoTruncate()` was failing before.