### PR TITLE
Added "provide" property for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "require-dev": {
         "php-ds/tests": "^1.2"
     },
+    "provide": {
+        "ext-ds": "1.0.0"
+    },
     "suggest": {
         "ext-ds": "to improve performance and reduce memory usage"
     },


### PR DESCRIPTION
This tells composer that this package provides the polyfill for "ext-ds". A typical use case would be that a library in a project requires "ext-ds". This package can then be added as a polyfill and composer will accept it.