### PR TITLE
Fix handling of initial capacity for Deque

### DIFF
--- a/src/Traits/GenericSequence.php
+++ b/src/Traits/GenericSequence.php
@@ -31,6 +31,11 @@ trait GenericSequence
         foreach ($values as $value) {
             $this->push($value);
         }
+
+        $this->capacity = max(
+            $values === null ? 0 : count($values),
+            $this::MIN_CAPACITY
+        );
     }
 
     /**


### PR DESCRIPTION
This fixes test failures

```
1) Ds\Tests\StackTest::testAutoTruncate
Failed asserting that 90 matches expected 64.
/home/travis/build/simPod/polyfill/vendor/php-ds/tests/tests/Vector/capacity.php:49

2) Ds\Tests\VectorTest::testAutoTruncate
Failed asserting that 90 matches expected 64.
/home/travis/build/simPod/polyfill/vendor/php-ds/tests/tests/Vector/capacity.php:49
```