### PR TITLE
Add ReturnTypeWillChange annotation

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -798,6 +798,7 @@ final class Map implements Collection, \ArrayAccess
      *
      * @see \JsonSerializable
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return (object) $this->toArray();

--- a/src/Pair.php
+++ b/src/Pair.php
@@ -142,6 +142,7 @@ final class Pair implements \JsonSerializable
      *
      * @psalm-return array{key: TKey, value: TValue}
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Traits/GenericCollection.php
+++ b/src/Traits/GenericCollection.php
@@ -27,6 +27,7 @@ trait GenericCollection
      *
      * @see \JsonSerializable
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();


### PR DESCRIPTION
When run with PHP 8.1, including the class triggers "Declaration of Ds\Map::jsonSerialize() should be compatible with JsonSerializable::jsonSerialize(): mixed".  Add the ReturnTypeWillChange attribute as per https://wiki.php.net/rfc/internal_method_return_types#proposal (backwards compatible, will be treated as a comment before PHP 8).﻿
