### PR TITLE
Optimize Map

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,18 @@
             "email": "rudolf.theunissen@gmail.com"
         }
     ],
+    "repositories": [
+       {
+          "type": "vcs",
+          "url": "git@github.com:iFixit/php-ds-tests.git"
+       }
+    ],
     "require": {
         "php": ">=7.1.0",
         "ext-json": "*"
     },
     "require-dev": {
-        "php-ds/tests": "^1.3"
+        "php-ds/tests": "dev-php8"
     },
     "provide": {
         "ext-ds": "1.3.0"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-ds": "to improve performance and reduce memory usage"
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "php --no-php-ini ./vendor/bin/phpunit"
     },
     "autoload": {
         "psr-4" : {

--- a/src/Map.php
+++ b/src/Map.php
@@ -382,7 +382,9 @@ final class Map implements Collection, \ArrayAccess
     {
         $filtered = new self();
 
-        foreach ($this as $key => $value) {
+        foreach ($this->pairRefs as $pairRef) {
+            $key = $pairRef->key;
+            $value = $pairRef->value;
             if ($callback ? $callback($key, $value) : $value) {
                 $filtered->put($key, $value);
             }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,4 +4,7 @@ namespace Ds;
 
 require __DIR__ . '/../vendor/autoload.php';
 
+// Give ourselves a healthy amount of memory to work with.
+ini_set('memory_limit', '1G');
+
 error_reporting(E_ALL);


### PR DESCRIPTION
`Map` as previously implemented used a linear search to find keys, resulting in O(n) put/delete performance, which isn't what one expects from a map (or a `Set`, which uses `Map` under the hood). It's slower than we find acceptable for general use. This appears to have been intentional, to keep the implementation simple, but that makes the class more of a reference implementation than a polyfill, and we actually want a polyfill, to allow us to use the `Ds` interface while we figure out the source of a segfault in the extension.

To improve the situation, we implement `Map` using two parallel arrays: one to maintain order (required by the interface) and another to provide a lookup table by key. We store the same `PairRef` (a container for key and value) in both tables so that finding a pair in either array is sufficient to find it in the other one, even as the order array changes.

This approach leads to a Map/Set implementation that's _roughly_ 8 times slower than using `SplObjectStorage` for `new stdClass` instances and 5 times slower than using native arrays directly for integers, and uses roughly 3 times more memory across the board. For example, storing around 32K integers eats up ~2M for a native array and ~6M in our Map, and takes 5–10ms for the native array versus ~25ms for our Map. It's not surprising that the PHP implementation is slower and more memory hungry than the C implementations, but the new Map/Set polyfill is _significantly_ faster than the previous one (which had made it less than 1% through the benchmark after 10 minutes where the new implementation finishes the benchmark in about 2 minutes) for a modest increase in memory usage (because we add a lookup table to the ordered list of pairs).

In order to test on PHP 8 (and on a machine with the extension enabled), I had to make some minor changes to the test config and the test suite. Note that we use a fork of the test repo, and we use the `php8` branch on that fork.

---

After these changes, we still need to implement custom serialization logic on the polyfill so that its serialized data is compatible with serialized data created by the extension.