### PR TITLE
Add missing ReturnTypeWillChange annotations

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -731,9 +731,6 @@ final class Map implements Collection, \ArrayAccess
         });
     }
 
-    /**
-     * @inheritDoc
-     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {

--- a/src/Map.php
+++ b/src/Map.php
@@ -731,6 +731,9 @@ final class Map implements Collection, \ArrayAccess
         });
     }
 
+    /**
+     * @inheritDoc
+     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -291,6 +291,7 @@ final class PriorityQueue implements Collection
     /**
      * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         while ( ! $this->isEmpty()) {

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -288,6 +288,9 @@ final class PriorityQueue implements Collection
         return $array;
     }
 
+    /**
+     * @inheritDoc
+     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -288,9 +288,6 @@ final class PriorityQueue implements Collection
         return $array;
     }
 
-    /**
-     * @inheritDoc
-     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -128,6 +128,7 @@ final class Queue implements Collection, \ArrayAccess
     /**
      * Get iterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         while ( ! $this->isEmpty()) {

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -129,6 +129,9 @@ final class Stack implements Collection, \ArrayAccess
         return array_reverse($this->vector->toArray());
     }
 
+    /**
+     *
+     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -129,9 +129,6 @@ final class Stack implements Collection, \ArrayAccess
         return array_reverse($this->vector->toArray());
     }
 
-    /**
-     * @inheritDoc
-     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -130,8 +130,9 @@ final class Stack implements Collection, \ArrayAccess
     }
 
     /**
-     *
+     * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         while ( ! $this->isEmpty()) {

--- a/src/Traits/GenericSequence.php
+++ b/src/Traits/GenericSequence.php
@@ -349,9 +349,6 @@ trait GenericSequence
         return $index >= 0 && $index < count($this);
     }
 
-    /**
-     * @inheritDoc
-     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {

--- a/src/Traits/GenericSequence.php
+++ b/src/Traits/GenericSequence.php
@@ -350,8 +350,9 @@ trait GenericSequence
     }
 
     /**
-     *
+     * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         foreach ($this->array as $value) {

--- a/src/Traits/GenericSequence.php
+++ b/src/Traits/GenericSequence.php
@@ -349,6 +349,9 @@ trait GenericSequence
         return $index >= 0 && $index < count($this);
     }
 
+    /**
+     *
+     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {


### PR DESCRIPTION
This is related to #80 (instances of \IteratorAggregate missing PHP 8.1 ReturnTypeWillChange annotations)