### PR TITLE
Fix PHP 8.1 deprecations

### DIFF
--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -120,7 +120,7 @@ final class PriorityQueue implements Collection
      */
     private function parent(int $index): int
     {
-        return ($index - 1) / 2;
+        return (int) (($index - 1) / 2);
     }
 
     /**

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -178,6 +178,7 @@ final class Queue implements Collection, \ArrayAccess
      *
      * @throws Error
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         throw new Error();

--- a/src/Set.php
+++ b/src/Set.php
@@ -243,7 +243,7 @@ final class Set implements Collection, \ArrayAccess
      */
     public function join(string $glue = null): string
     {
-        return implode($glue, $this->toArray());
+        return implode($glue ?? '', $this->toArray());
     }
 
     /**

--- a/src/Traits/Capacity.php
+++ b/src/Traits/Capacity.php
@@ -11,7 +11,7 @@ use Ds\Deque;
 trait Capacity
 {
     /**
-     * @var integer internal capacity
+     * @var int internal capacity
      */
     private $capacity = self::MIN_CAPACITY;
 
@@ -95,7 +95,7 @@ trait Capacity
 
     protected function nextCapacity(): int
     {
-        return $this->capacity() * $this->getGrowthFactor();
+        return (int) ($this->capacity() * $this->getGrowthFactor());
     }
 
     /**
@@ -116,7 +116,7 @@ trait Capacity
     {
         $this->capacity = max(
             self::MIN_CAPACITY,
-            $this->capacity()  * $this->getDecayFactor()
+            (int) ($this->capacity()  * $this->getDecayFactor())
         );
     }
 

--- a/src/Traits/GenericSequence.php
+++ b/src/Traits/GenericSequence.php
@@ -148,7 +148,7 @@ trait GenericSequence
      */
     public function join(string $glue = null): string
     {
-        return implode($glue, $this->array);
+        return implode($glue ?? '', $this->array);
     }
 
     /**


### PR DESCRIPTION
- Make implicit int cast explicit in `Capacity::decreaseCapacity()`, `Capacity::netCapacity()`, `PriorityQueue::parent()`
- Do not pass null as a separator to `implode()`
- Add ReturnTypeWillChange to `Queue::offsetExists()`

Prevents PHP 8.1 errors: 
- PHP Deprecated: Implicit conversion from float 40.5 to int loses precision
- PHP Deprecated:  implode(): Passing null to parameter 1 ($separator) of type array|string is deprecated

Rest is in https://github.com/php-ds/polyfill/pull/91 and https://github.com/php-ds/tests/pull/21