### PR TITLE
Changed the docblock summary for push()

### DIFF
--- a/src/Queue.php
+++ b/src/Queue.php
@@ -106,7 +106,7 @@ final class Queue implements Collection, \ArrayAccess
     }
 
     /**
-     * Pushes zero or more values into the front of the queue.
+     * Pushes zero or more values into the back of the queue.
      *
      * @param mixed ...$values
      *


### PR DESCRIPTION
The summary stated that `push()` would **push** the values **into the front** of the queue.

The php.net docs and wikipedia (linked from the `ds-ext` blog post) state that values are *pushed onto the back* of the queue and *popped off the front* of the queue.

I think it should either:
- push values into the queue from the back OR
- push values onto the back of the queue

I hope my understanding is correct and the explanation makes sense. :S be blunt if anything is wrong, I don't want to waste your time.

If this is right, I think we should also update the class docblock summary to mention that values are pushed onto the back.

A “first in, first out” or “FIFO” collection that pushes new values into the back of the queue but only allows access to the value at the front of the queue and iterates in order from the front, destructively.