### PR TITLE
Fix PHPDoc `@extends` for `Collection` interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- `Collection` PHPDoc now correctly states that it extends `IteratorAggregate`, rather than just `Traversable`.
+
+## [1.4.1] - 2022-03-09
+
+## [1.4.0] - 2021-11-17
+
 ## [1.3.0] - 2020-10-13
 ### Changed
 - Implement ArrayAccess consistently

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -10,7 +10,7 @@ namespace Ds;
  *
  * @template-covariant TKey
  * @template-covariant TValue
- * @extends Traversable<TKey, TValue>
+ * @extends \IteratorAggregate<TKey, TValue>
  */
 interface Collection extends \IteratorAggregate, \Countable, \JsonSerializable
 {


### PR DESCRIPTION
This PR fixes the `Collection` PHPDoc so it correctly states that it extends `IteratorAggregate`, rather than just `Traversable`.