### PR TITLE
fix Psalm annotations for traits and their usages

### DIFF
--- a/src/Deque.php
+++ b/src/Deque.php
@@ -13,6 +13,8 @@ namespace Ds;
  *
  * @template TValue
  * @implements Sequence<TValue>
+ * @template-use Traits\GenericCollection<int, TValue>
+ * @template-use Traits\GenericSequence<TValue>
  */
 final class Deque implements Sequence
 {

--- a/src/Map.php
+++ b/src/Map.php
@@ -16,6 +16,7 @@ use UnderflowException;
  * @template TKey
  * @template TValue
  * @implements Collection<TKey, TValue>
+ * @template-use Traits\GenericCollection<TKey, TValue>
  */
 final class Map implements Collection, \ArrayAccess
 {

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -12,6 +12,7 @@ use OutOfBoundsException;
  *
  * @template TValue
  * @implements Collection<int, TValue>
+ * @template-use Traits\GenericCollection<int, TValue>
  */
 final class Queue implements Collection, \ArrayAccess 
 {

--- a/src/Set.php
+++ b/src/Set.php
@@ -12,6 +12,7 @@ use OutOfRangeException;
  *
  * @template TValue
  * @implements Collection<int, TValue>
+ * @template-use Traits\GenericCollection<int, TValue>
  */
 final class Set implements Collection, \ArrayAccess 
 {

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -12,6 +12,7 @@ use OutOfBoundsException;
  *
  * @template TValue
  * @implements Sequence<TValue>
+ * @template-use Traits\GenericCollection<int, TValue>
  */
 final class Stack implements Collection, \ArrayAccess
 {

--- a/src/Traits/GenericCollection.php
+++ b/src/Traits/GenericCollection.php
@@ -3,6 +3,8 @@ namespace Ds\Traits;
 
 /**
  * Common to structures that implement the base collection interface.
+ * @template-covariant TKey
+ * @template-covariant TValue
  */
 trait GenericCollection
 {
@@ -37,6 +39,8 @@ trait GenericCollection
      * Creates a shallow copy of the collection.
      *
      * @return static a shallow copy of the collection.
+     *
+     * @psalm-return static<TKey, TValue>
      */
     public function copy(): self
     {
@@ -51,6 +55,8 @@ trait GenericCollection
      * could not be created (for example when object are used as keys).
      *
      * @return array
+     *
+     * @psalm-return array<TKey, TValue>
      */
     abstract public function toArray(): array;
 

--- a/src/Traits/GenericSequence.php
+++ b/src/Traits/GenericSequence.php
@@ -11,6 +11,8 @@ use UnderflowException;
  * share the same implementation using an array array.
  *
  * @package Ds\Traits
+ *
+ * @template TValue
  */
 trait GenericSequence
 {
@@ -39,7 +41,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritdoc
+     * @return list<TValue>
      */
     public function toArray(): array
     {
@@ -47,7 +49,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritdoc
+     * @psalm-param callable(TValue): TValue $callback
      */
     public function apply(callable $callback)
     {
@@ -57,7 +59,9 @@ trait GenericSequence
     }
 
     /**
-     * @inheritdoc
+     * @template TValue2
+     * @psalm-param iterable<TValue2> $values
+     * @psalm-return Sequence<TValue|TValue2>
      */
     public function merge($values): Sequence
     {
@@ -67,7 +71,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritdoc
+     *
      */
     public function count(): int
     {
@@ -75,7 +79,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @psalm-param TValue ...$values
      */
     public function contains(...$values): bool
     {
@@ -89,7 +93,8 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @psalm-param (callable(TValue): bool)|null $callback
+     * @psalm-return Sequence<TValue>
      */
     public function filter(callable $callback = null): Sequence
     {
@@ -97,7 +102,9 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @return int|null
+     *
+     * @psalm-param TValue $value
      */
     public function find($value)
     {
@@ -107,7 +114,9 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @throws \UnderflowException if the sequence is empty.
+     *
+     * @psalm-return TValue
      */
     public function first()
     {
@@ -119,7 +128,9 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @throws \OutOfRangeException if the index is not in the range [0, size-1]
+     *
+     * @psalm-return TValue
      */
     public function get(int $index)
     {
@@ -131,7 +142,9 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @throws \OutOfRangeException if the index is not in the range [0, n]
+     *
+     * @psalm-param TValue ...$values
      */
     public function insert(int $index, ...$values)
     {
@@ -144,7 +157,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     *
      */
     public function join(string $glue = null): string
     {
@@ -152,7 +165,9 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @throws \UnderflowException if the sequence is empty.
+     *
+     * @psalm-return TValue
      */
     public function last()
     {
@@ -164,7 +179,9 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @template TNewValue
+     * @psalm-param callable(TValue): TNewValue $callback
+     * @psalm-return Sequence<TNewValue>
      */
     public function map(callable $callback): Sequence
     {
@@ -172,7 +189,8 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @throws \UnderflowException if the sequence is empty.
+     * @psalm-return TValue
      */
     public function pop()
     {
@@ -187,7 +205,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @psalm-param TValue ...$values
      */
     public function push(...$values)
     {
@@ -199,7 +217,10 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @template TCarry
+     * @psalm-param callable(TCarry, TValue): TCarry $callback
+     * @psalm-param TCarry $initial
+     * @psalm-return TCarry
      */
     public function reduce(callable $callback, $initial = null)
     {
@@ -207,7 +228,9 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @throws \OutOfRangeException if the index is not in the range [0, size-1]
+     *
+     * @psalm-return TValue
      */
     public function remove(int $index)
     {
@@ -222,7 +245,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     *
      */
     public function reverse()
     {
@@ -230,7 +253,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @psalm-return Sequence<TValue>
      */
     public function reversed(): Sequence
     {
@@ -252,7 +275,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     *
      */
     public function rotate(int $rotations)
     {
@@ -262,7 +285,9 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @throws \OutOfRangeException if the index is not in the range [0, size-1]
+     *
+     * @psalm-param TValue $value
      */
     public function set(int $index, $value)
     {
@@ -274,7 +299,9 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @throws \UnderflowException if the sequence was empty.
+     *
+     * @psalm-return TValue
      */
     public function shift()
     {
@@ -289,7 +316,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @psalm-return Sequence<TValue>
      */
     public function slice(int $offset, int $length = null): Sequence
     {
@@ -301,7 +328,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @psalm-param (callable(TValue, TValue): int)|null $comparator
      */
     public function sort(callable $comparator = null)
     {
@@ -313,7 +340,8 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @psalm-param (callable(TValue, TValue): int)|null $comparator
+     * @psalm-return Sequence<TValue>
      */
     public function sorted(callable $comparator = null): Sequence
     {
@@ -323,7 +351,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @return int|float
      */
     public function sum()
     {
@@ -331,7 +359,7 @@ trait GenericSequence
     }
 
     /**
-     * @inheritDoc
+     * @psalm-param TValue ...$values
      */
     public function unshift(...$values)
     {

--- a/src/Vector.php
+++ b/src/Vector.php
@@ -11,6 +11,8 @@ namespace Ds;
  *
  * @template TValue
  * @implements Sequence<TValue>
+ * @template-use Traits\GenericCollection<int, TValue>
+ * @template-use Traits\GenericSequence<TValue>
  */
 final class Vector implements Sequence
 {


### PR DESCRIPTION
I found that I have problems with validating such code via psalm:

```php
class Container
{
    /** @param Sequence<string> $strings */
    public function __construct(Sequence $strings) {}
}

new Container(new Vector());
```

It's because `__construct()` of the `Vector` is described in `GenericSequence` trait which is typed incorrectly: generic types are only defined in interfaces, but not in traits. This PR fixes that, adds `@template-use` annotations to trait clients, and also removes meaningless `@inheritDoc` annotation from `GenericSequence`, which by the way was not used in `GenericCollection` (traits have no inheritance tree).