### PR TITLE
Fix incorrect return type description for `Set#contains()`.

### DIFF
--- a/src/Set.php
+++ b/src/Set.php
@@ -92,8 +92,8 @@ final class Set implements Collection, \ArrayAccess
      *
      * @param mixed ...$values
      *
-     * @return bool true if at least one value was provided and the set
-     *              contains all given values, false otherwise.
+     * @return bool false if any of the provided values are not in the set;
+     *              true otherwise.
      *
      * @psalm-param TValue ...$values
      */


### PR DESCRIPTION
The current return type description is confusing, since it implies that an empty `$values` would cause the method to return `false`, when in fact, it would return `true`.

The corrected description is based on https://www.php.net/manual/en/ds-set.contains.php#refsect1-ds-set.contains-returnvalues