### PR TITLE
Fix deprecation notices

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -287,7 +287,7 @@ final class Map implements Collection, \ArrayAccess
      * @psalm-param (callable(TKey, TValue): bool)|null $callback
      * @psalm-return Map<TKey, TValue>
      */
-    public function filter(callable $callback = null): Map
+    public function filter(?callable $callback = null): Map
     {
         $filtered = new self();
 
@@ -552,7 +552,7 @@ final class Map implements Collection, \ArrayAccess
      *
      * @psalm-return Map<TKey, TValue>
      */
-    public function slice(int $offset, int $length = null): Map
+    public function slice(int $offset, ?int $length = null): Map
     {
         $map = new self();
 
@@ -578,7 +578,7 @@ final class Map implements Collection, \ArrayAccess
      *
      * @psalm-param (callable(TValue, TValue): int)|null $comparator
      */
-    public function sort(callable $comparator = null)
+    public function sort(?callable $comparator = null)
     {
         if ($comparator) {
             usort($this->pairs, function($a, $b) use ($comparator) {
@@ -603,7 +603,7 @@ final class Map implements Collection, \ArrayAccess
      * @psalm-param (callable(TValue, TValue): int)|null $comparator
      * @psalm-return Map<TKey, TValue>
      */
-    public function sorted(callable $comparator = null): Map
+    public function sorted(?callable $comparator = null): Map
     {
         $copy = $this->copy();
         $copy->sort($comparator);
@@ -619,7 +619,7 @@ final class Map implements Collection, \ArrayAccess
      *
      * @psalm-param (callable(TKey, TKey): int)|null $comparator
      */
-    public function ksort(callable $comparator = null)
+    public function ksort(?callable $comparator = null)
     {
         if ($comparator) {
             usort($this->pairs, function($a, $b) use ($comparator) {
@@ -644,7 +644,7 @@ final class Map implements Collection, \ArrayAccess
      * @psalm-param (callable(TKey, TKey): int)|null $comparator
      * @psalm-return Map<TKey, TValue>
      */
-    public function ksorted(callable $comparator = null): Map
+    public function ksorted(?callable $comparator = null): Map
     {
         $copy = $this->copy();
         $copy->ksort($comparator);

--- a/src/Set.php
+++ b/src/Set.php
@@ -177,7 +177,7 @@ final class Set implements Collection, \ArrayAccess
      * @psalm-param (callable(TValue): bool)|null $callback
      * @psalm-return Set<TValue>
      */
-    public function filter(callable $callback = null): Set
+    public function filter(?callable $callback = null): Set
     {
         return new self(array_filter($this->toArray(), $callback ?: 'boolval'));
     }
@@ -243,7 +243,7 @@ final class Set implements Collection, \ArrayAccess
      *
      * @param string|null $glue
      */
-    public function join(string $glue = null): string
+    public function join(?string $glue = null): string
     {
         return implode($glue ?? '', $this->toArray());
     }
@@ -363,7 +363,7 @@ final class Set implements Collection, \ArrayAccess
      *
      * @psalm-return Set<TValue>
      */
-    public function slice(int $offset, int $length = null): Set
+    public function slice(int $offset, ?int $length = null): Set
     {
         $sliced = new self();
         $sliced->table = $this->table->slice($offset, $length);
@@ -379,7 +379,7 @@ final class Set implements Collection, \ArrayAccess
      *
      * @psalm-param (callable(TValue, TValue): int)|null $comparator
      */
-    public function sort(callable $comparator = null)
+    public function sort(?callable $comparator = null)
     {
         $this->table->ksort($comparator);
     }
@@ -396,7 +396,7 @@ final class Set implements Collection, \ArrayAccess
      * @psalm-param (callable(TValue, TValue): int)|null $comparator
      * @psalm-return Set<TValue>
      */
-    public function sorted(callable $comparator = null): Set
+    public function sorted(?callable $comparator = null): Set
     {
         $sorted = $this->copy();
         $sorted->table->ksort($comparator);


### PR DESCRIPTION
This should fix `Implicitly marking parameter $param as nullable is deprecated, the explicit nullable type must be used instead` PHP 8.4 notices in Set and Map classes. Works towards #108

Nullable type hinting came in in 7.1 so no need to update composer.json here as it's currently on 7.4 anyway